### PR TITLE
Added initial stress tests of PhysicsBody3D.move_and_collide

### DIFF
--- a/base/class/monitor.gd
+++ b/base/class/monitor.gd
@@ -30,7 +30,8 @@ func _process(delta: float) -> void:
 	monitor_duration += delta
 	if monitor_duration > monitor_maximum_duration:
 		error_message = "The maximum duration has been exceeded (> %.1f s)" % [monitor_maximum_duration]
-		return monitor_completed()
+		monitor_completed()
+		return
 
 func monitor_name() -> String:
 	@warning_ignore(assert_always_false)

--- a/base/monitors/generic_expiration_monitor.gd
+++ b/base/monitors/generic_expiration_monitor.gd
@@ -28,7 +28,8 @@ func _process(delta: float) -> void:
 	monitor_duration += delta
 	if monitor_duration > monitor_maximum_duration:
 		success = test_lambda.call(target, self)
-		return monitor_completed()
+		monitor_completed()
+		return
 		
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _physics_process(_delta: float) -> void:

--- a/base/monitors/generic_manual_monitor.gd
+++ b/base/monitors/generic_manual_monitor.gd
@@ -27,7 +27,8 @@ func _process(delta: float) -> void:
 	monitor_duration += delta
 	if monitor_duration > monitor_maximum_duration:
 		error_message = "The maximum duration has been exceeded (> %.1f s)" % [monitor_maximum_duration]
-		return monitor_completed()
+		monitor_completed()
+		return
 		
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _physics_process(_delta: float) -> void:

--- a/base/monitors/generic_step_monitor.gd
+++ b/base/monitors/generic_step_monitor.gd
@@ -42,7 +42,8 @@ func _process(delta: float) -> void:
 	monitor_duration += delta
 	if monitor_duration > monitor_maximum_duration:
 		error_message = "The maximum duration has been exceeded (> %.1f s)" % [monitor_maximum_duration]
-		return monitor_completed()
+		monitor_completed()
+		return
 		
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _physics_process(_delta: float) -> void:
@@ -50,7 +51,8 @@ func _physics_process(_delta: float) -> void:
 	# If all steps are completed
 	var last_step = total_step - 1
 	if current_step == last_step:
-		return passed()
+		passed()
+		return
 	
 	if physics_step_cbk:
 		physics_step_cbk.call(current_step, target, first_iteration, self)
@@ -58,7 +60,8 @@ func _physics_process(_delta: float) -> void:
 	# Test according to the lambda provided
 	var result = test_lambda.call(current_step, target, self)
 	if first_iteration and not result:
-		return failed("The verification of the first step has failed")
+		failed("The verification of the first step has failed")
+		return
 	first_iteration = false	
 	
 	# If the test is false, we checks if we can pass to the next step
@@ -66,7 +69,8 @@ func _physics_process(_delta: float) -> void:
 		var is_next = test_lambda.call(current_step + 1, target, self)
 		
 		if not is_next:
-			return failed("Error during the transition from step %d to step %d" % [current_step, current_step + 1])
+			failed("Error during the transition from step %d to step %d" % [current_step, current_step + 1])
+			return
 		else:
 			current_step += 1
 			if physics_step_cbk:

--- a/tests/nodes/PhysicsBody/physics_body_3d.tscn
+++ b/tests/nodes/PhysicsBody/physics_body_3d.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="PackedScene" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.tscn" id="1_qsgnv"]
+[ext_resource type="PackedScene" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.tscn" id="2_0pbta"]
+[ext_resource type="PackedScene" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.tscn" id="3_5xjmy"]
+
+[sub_resource type="GDScript" id="GDScript_13ds0"]
+script/source = "extends TestScene
+"
+
+[node name="physics_body_3d" type="Node3D"]
+script = SubResource("GDScript_13ds0")
+
+[node name="collide_sphere_sphere" parent="." instance=ExtResource("1_qsgnv")]
+
+[node name="collide_sphere_cylinder" parent="." instance=ExtResource("2_0pbta")]
+
+[node name="collide_sphere_capsule" parent="." instance=ExtResource("3_5xjmy")]

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.gd
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.gd
@@ -1,0 +1,123 @@
+extends PhysicsUnitTest3D
+
+
+# Tolerances
+const POSITION_TOLERANCE := 0.01
+const NORMAL_TOLERANCE := 0.01
+
+
+var simulation_duration := 20
+var test_failed := false
+
+func test_description() -> String:
+	return """Checks whether the move_and_collide between sphere and capsule works
+	correctly."""
+	
+func test_name() -> String:
+	return "PhysicsBody3D | testing collide sphere with capsule"
+
+
+var tested_body: CharacterBody3D
+var static_body: StaticBody3D
+
+func start() -> void:
+	tested_body = $Tested
+	static_body = $Static
+	
+	var test_lambda: Callable = func(p_target, p_monitor: GenericManualMonitor):
+		# Get the test block and index
+		var test_block := int(p_monitor.frame / 100)
+		var test_index := int(p_monitor.frame % 100)
+
+		# Get the test raster positions X/Y/Theta
+		var r1 : float = floor(test_index / 10) - 5.0
+		var r2 : float = (test_index % 10) - 5.0
+		var rt : float = test_index * TAU / 100.0
+
+		# Pick the start position and move direction
+		var start : Vector3
+		var move : Vector3
+		var position_expected : Vector3
+		var normal_expected : Vector3
+		match test_block:
+			0:		# Collide from X+ direction
+				start = Vector3(103, r1, r2)
+				move = Vector3(-10, 0, 0)
+
+			1:		# Collide from X- direction
+				start = Vector3(-103, r1, r2)
+				move = Vector3(10, 0, 0)
+
+			2:		# Collide from Y+ direction
+				start = Vector3(r1, 53, r2)
+				move = Vector3(0, -10, 0)
+
+			3:		# Collide from Y- direction
+				start = Vector3(r1, -53, r2)
+				move = Vector3(0, 10, 0)
+
+			4:		# Collide from Z+ direction
+				start = Vector3(r1, r2, 53)
+				move = Vector3(0, 0, -10)
+
+			5:		# Collide from Z- direction
+				start = Vector3(r1, r2, -53)
+				move = Vector3(0, 0, 10)
+
+			6:		# Collide from ring in middle
+				start = Vector3(0, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+
+			7:		# Collide from ring atX+ end
+				start = Vector3(50, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+
+			8:		# Collide from ring atX+ end
+				start = Vector3(-50, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+
+			_:		# End of test
+				p_monitor.passed()
+				return
+
+		# If expected position or normal are blank then deduce from cross-section collision
+		if position_expected.is_zero_approx() or normal_expected.is_zero_approx():
+			var sp := Geometry3D.get_closest_point_to_segment(
+				start,
+				Vector3(-50, 0, 0),
+				Vector3(50, 0, 0))
+			var c := Geometry3D.segment_intersects_sphere(
+				start,
+				start + move,
+				sp,
+				51)
+			if c.size() < 2:
+				p_monitor.failed()
+				return
+
+			position_expected = c[0] - c[1]
+			normal_expected = c[1]
+
+		# Set the position and perform the move_and_collide
+		tested_body.global_position = start
+		var collision : KinematicCollision3D = tested_body.move_and_collide(move)
+		if !collision:
+			p_monitor.failed()
+			return
+
+		# Check the collision is on ths sphere
+		var position_actual := collision.get_position()
+		var position_error := position_expected.distance_to(position_actual)
+		if position_error > POSITION_TOLERANCE:
+			p_monitor.failed()
+			return
+
+		# Verify collision normal matches expected
+		var normal_actual := collision.get_normal()
+		var normal_error := normal_expected.distance_to(normal_actual)
+		if normal_error > NORMAL_TOLERANCE:
+			p_monitor.failed()
+			return
+
+	var collision_monitor := create_generic_manual_monitor(self, test_lambda, simulation_duration)
+	collision_monitor.test_name = "move_and_collide for sphere and capsule are detected correctly"

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.tscn
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_capsule.gd" id="1_s4rkq"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_b3iet"]
+radius = 1.0
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_cgxs3"]
+radius = 50.0
+height = 200.0
+
+[node name="collide_sphere_capsule" type="Node3D"]
+script = ExtResource("1_s4rkq")
+
+[node name="Camera" type="Camera3D" parent="."]
+transform = Transform3D(0.996195, -0.00759612, 0.0868241, 0, 0.996195, 0.0871557, -0.0871557, -0.0868241, 0.992404, 20, 30, 180)
+
+[node name="Tested" type="CharacterBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Tested"]
+shape = SubResource("SphereShape3D_b3iet")
+
+[node name="Static" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Static"]
+transform = Transform3D(-4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0)
+shape = SubResource("CapsuleShape3D_cgxs3")

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.gd
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.gd
@@ -1,0 +1,141 @@
+extends PhysicsUnitTest3D
+
+
+# Tolerances
+const POSITION_TOLERANCE := 0.01
+const NORMAL_TOLERANCE := 0.005
+
+
+var simulation_duration := 20
+var test_failed := false
+
+func test_description() -> String:
+	return """Checks whether the move_and_collide between sphere and cylinder works
+	correctly."""
+	
+func test_name() -> String:
+	return "PhysicsBody3D | testing collide sphere with cylinder"
+
+
+var tested_body: CharacterBody3D
+var static_body: StaticBody3D
+
+func start() -> void:
+	tested_body = $Tested
+	static_body = $Static
+	
+	var test_lambda: Callable = func(p_target, p_monitor: GenericManualMonitor):
+		# Get the test block and index
+		var test_block := int(p_monitor.frame / 100)
+		var test_index := int(p_monitor.frame % 100)
+
+		# Get the test raster positions X/Y/Theta
+		var r1 : float = floor(test_index / 10) - 5.0
+		var r2 : float = (test_index % 10) - 5.0
+		var rt : float = test_index * TAU / 100.0
+
+		# Pick the start position and move direction
+		var start : Vector3
+		var move : Vector3
+		var position_expected : Vector3
+		var normal_expected : Vector3
+		match test_block:
+			0:		# Collide from X+ direction
+				start = Vector3(103, r1, r2)
+				move = Vector3(-10, 0, 0)
+				position_expected = Vector3(100, r1, r2)
+				normal_expected = Vector3(1, 0, 0)
+
+			1:		# Collide from X- direction
+				start = Vector3(-103, r1, r2)
+				move = Vector3(10, 0, 0)
+				position_expected = Vector3(-100, r1, r2)
+				normal_expected = Vector3(-1, 0, 0)
+
+			2:		# Collide from Y+ direction
+				start = Vector3(r1, 53, r2)
+				move = Vector3(0, -10, 0)
+
+			3:		# Collide from Y- direction
+				start = Vector3(r1, -53, r2)
+				move = Vector3(0, 10, 0)
+
+			4:		# Collide from Z+ direction
+				start = Vector3(r1, r2, 53)
+				move = Vector3(0, 0, -10)
+
+			5:		# Collide from Z- direction
+				start = Vector3(r1, r2, -53)
+				move = Vector3(0, 0, 10)
+
+			6:		# Collide from ring in middle
+				start = Vector3(0, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+				position_expected = Vector3(0, sin(rt) * 50, cos(rt) * 50)
+				normal_expected = Vector3(0, sin(rt) * 1, cos(rt) * 1)
+
+			7:		# Collide from ring near X+ end
+				start = Vector3(95, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+				position_expected = Vector3(95, sin(rt) * 50, cos(rt) * 50)
+				normal_expected = Vector3(0, sin(rt) * 1, cos(rt) * 1)
+
+			8:		# Collide from ring near X- end
+				start = Vector3(-95, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+				position_expected = Vector3(-95, sin(rt) * 50, cos(rt) * 50)
+				normal_expected = Vector3(0, sin(rt) * 1, cos(rt) * 1)
+			
+			9:		# Collide from X+ ring
+				start = Vector3(103, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(-10, sin(rt) * -10, cos(rt) * -10)
+				position_expected = Vector3(100, sin(rt) * 50, cos(rt) * 50)
+				normal_expected = Vector3(0.7071, sin(rt) * 0.7071, cos(rt) * 0.7071)
+
+			10:		# Collide from X- ring
+				start = Vector3(-103, sin(rt) * 53, cos(rt) * 53)
+				move = Vector3(10, sin(rt) * -10, cos(rt) * -10)
+				position_expected = Vector3(-100, sin(rt) * 50, cos(rt) * 50)
+				normal_expected = Vector3(-0.7071, sin(rt) * 0.7071, cos(rt) * 0.7071)
+
+			_:		# End of test
+				p_monitor.passed()
+				return
+
+		# If expected position or normal are blank then deduce from cross-section collision
+		if position_expected.is_zero_approx() or normal_expected.is_zero_approx():
+			var c := Geometry3D.segment_intersects_sphere(
+				start,
+				start + move,
+				start * Vector3.RIGHT,
+				51)
+			if c.size() < 2:
+				p_monitor.failed()
+				return
+
+			position_expected = c[0] - c[1]
+			normal_expected = c[1]
+
+		# Set the position and perform the move_and_collide
+		tested_body.global_position = start
+		var collision : KinematicCollision3D = tested_body.move_and_collide(move)
+		if !collision:
+			p_monitor.failed()
+			return
+
+		# Check the collision is on ths sphere
+		var position_actual := collision.get_position()
+		var position_error := position_expected.distance_to(position_actual)
+		if position_error > POSITION_TOLERANCE:
+			p_monitor.failed()
+			return
+
+		# Verify collision normal matches expected
+		var normal_actual := collision.get_normal()
+		var normal_error := normal_expected.distance_to(normal_actual)
+		if normal_error > NORMAL_TOLERANCE:
+			p_monitor.failed()
+			return
+
+	var collision_monitor := create_generic_manual_monitor(self, test_lambda, simulation_duration)
+	collision_monitor.test_name = "move_and_collide for sphere and cylinder are detected correctly"

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.tscn
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_cylinder.gd" id="1_rk3n4"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_wssea"]
+radius = 1.0
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_qkf6h"]
+height = 200.0
+radius = 50.0
+
+[node name="collide_sphere_cylinder" type="Node3D"]
+script = ExtResource("1_rk3n4")
+
+[node name="Camera" type="Camera3D" parent="."]
+transform = Transform3D(0.996195, -0.00759612, 0.0868241, 0, 0.996195, 0.0871557, -0.0871557, -0.0868241, 0.992404, 20, 30, 180)
+
+[node name="Tested" type="CharacterBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Tested"]
+shape = SubResource("SphereShape3D_wssea")
+
+[node name="Static" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Static"]
+transform = Transform3D(-4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0)
+shape = SubResource("CylinderShape3D_qkf6h")

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.gd
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.gd
@@ -1,0 +1,104 @@
+extends PhysicsUnitTest3D
+
+
+# Tolerances
+const POSITION_TOLERANCE := 0.01
+const NORMAL_TOLERANCE := 0.001
+
+
+var simulation_duration := 20
+var test_failed := false
+
+func test_description() -> String:
+	return """Checks whether the move_and_collide between sphere and sphere works
+	correctly."""
+	
+func test_name() -> String:
+	return "PhysicsBody3D | testing collide sphere with sphere"
+
+
+var tested_body: CharacterBody3D
+var static_body: StaticBody3D
+
+func start() -> void:
+	tested_body = $Tested
+	static_body = $Static
+	
+	var test_lambda: Callable = func(p_target, p_monitor: GenericManualMonitor):
+		# Get the test block and index
+		var test_block := int(p_monitor.frame / 100)
+		var test_index := int(p_monitor.frame % 100)
+
+		# Get the test raster positions X/Y/Theta
+		var r1 : float = floor(test_index / 10) - 5.0
+		var r2 : float = (test_index % 10) - 5.0
+		var rt : float = test_index * TAU / 100.0
+
+		# Pick the start position and move direction
+		var start : Vector3
+		var move : Vector3
+		match test_block:
+			0:		# Collide from X+ direction
+				start = Vector3(103, r1, r2)
+				move = Vector3(-10, 0, 0)
+
+			1:		# Collide from X- direction
+				start = Vector3(-103, r1, r2)
+				move = Vector3(10, 0, 0)
+
+			2:		# Collide from Y+ direction
+				start = Vector3(r1, 103, r2)
+				move = Vector3(0, -10, 0)
+
+			3:		# Collide from Y- direction
+				start = Vector3(r1, -103, r2)
+				move = Vector3(0, 10, 0)
+
+			4:		# Collide from Z+ direction
+				start = Vector3(r1, r2, 103)
+				move = Vector3(0, 0, -10)
+
+			5:		# Collide from Z- direction
+				start = Vector3(r1, r2, -103)
+				move = Vector3(0, 0, 10)
+			
+			6:		# Collide from Y/Z orbit
+				start = Vector3(0, sin(rt) * 103, cos(rt) * 103)
+				move = Vector3(0, sin(rt) * -10, cos(rt) * -10)
+
+			7:		# Collide from X/Z orbit
+				start = Vector3(sin(rt) * 103, 0, cos(rt) * 103)
+				move = Vector3(sin(rt) * -10, 0, cos(rt) * -10)
+
+			8:		# Collide from X/Y orbit
+				start = Vector3(sin(rt) * 103, cos(rt) * 103, 0)
+				move = Vector3(sin(rt) * -10, cos(rt) * -10, 0)
+
+			_:		# End of test
+				p_monitor.passed()
+				return
+
+		# Set the position and perform the move_and_collide
+		tested_body.global_position = start
+		var collision : KinematicCollision3D = tested_body.move_and_collide(move)
+		if !collision:
+			p_monitor.failed()
+			return
+
+		# Check the collision is on ths sphere
+		var position_actual := collision.get_position()
+		var distance := position_actual.length()
+		if abs(distance - 100) > POSITION_TOLERANCE:
+			p_monitor.failed()
+			return
+
+		# Verify collision normal matches expected
+		var normal_expected := position_actual.normalized()
+		var normal_actual := collision.get_normal()
+		var normal_error := normal_expected.distance_to(normal_actual)
+		if normal_error > NORMAL_TOLERANCE:
+			p_monitor.failed()
+			return
+
+	var collision_monitor := create_generic_manual_monitor(self, test_lambda, simulation_duration)
+	collision_monitor.test_name = "move_and_collide for sphere and sphere are detected correctly"

--- a/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.tscn
+++ b/tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://tests/nodes/PhysicsBody/tests/move_and_collide_3d/collide_sphere_sphere.gd" id="1_de8s5"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_c7khe"]
+radius = 1.0
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_1kwa5"]
+radius = 100.0
+
+[node name="collide_sphere_sphere" type="Node3D"]
+script = ExtResource("1_de8s5")
+
+[node name="Camera" type="Camera3D" parent="."]
+transform = Transform3D(0.996195, -0.00759612, 0.0868241, 0, 0.996195, 0.0871557, -0.0871557, -0.0868241, 0.992404, 20, 30, 180)
+
+[node name="Tested" type="CharacterBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Tested"]
+shape = SubResource("SphereShape3D_c7khe")
+
+[node name="Static" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Static"]
+shape = SubResource("SphereShape3D_1kwa5")


### PR DESCRIPTION
This pull request adds an initial set of PhysicsBody3D.move_and_collide stress tests to detect collision errors. I'm not sure I'm using the tool-kit correctly.

Additionally it seems like the 3D tests only run when their parent test scenes are executed.