### PR TITLE
Add tests for CharacterBody3D sliding along static bodies

### DIFF
--- a/base/class/physics_test_3d.gd
+++ b/base/class/physics_test_3d.gd
@@ -18,6 +18,7 @@ enum TestCollisionShape {
 	CONVEX_POLYGON_ULTRA_HIGH_VERTEX = 101,
 	BOX = PhysicsServer3D.SHAPE_BOX,
 	SPHERE = PhysicsServer3D.SHAPE_SPHERE,
+	CYLINDER = PhysicsServer3D.SHAPE_CYLINDER,
 }
 
 func _ready() -> void:
@@ -53,7 +54,6 @@ func get_static_body_with_collision_shape(p_shape_definition, p_shape_type := Te
 	body.add_child(body_col)
 	return body
 
-# Get CollisionShape2D or CollisionPolygon2D that fits in the rectangle.
 func get_collision_shape(p_shape_definition, p_shape_type := TestCollisionShape.BOX) -> Node3D:
 	var col = null
 	if p_shape_type == TestCollisionShape.CAPSULE:
@@ -62,13 +62,19 @@ func get_collision_shape(p_shape_definition, p_shape_type := TestCollisionShape.
 		col.shape = CapsuleShape3D.new()
 		col.shape.radius = p_shape_definition.x
 		col.shape.height = p_shape_definition.y
+	elif p_shape_type == TestCollisionShape.CYLINDER:
+		assert(p_shape_definition is Vector2, "Shape definition for a Cylinder must be a Vector2")
+		col = CollisionShape3D.new()
+		col.shape = CylinderShape3D.new()
+		col.shape.radius = p_shape_definition.x
+		col.shape.height = p_shape_definition.y
 	elif p_shape_type == TestCollisionShape.SPHERE:
-		assert(p_shape_definition is float, "Shape definition for a Circle must be a float")
+		assert(p_shape_definition is float, "Shape definition for a Sphere must be a float")
 		col = CollisionShape3D.new()
 		col.shape = SphereShape3D.new()
 		col.shape.radius = p_shape_definition
 	elif p_shape_type == TestCollisionShape.BOX:
-		assert(p_shape_definition is Vector3, "Shape definition for a Rectangle must be a Rect2")
+		assert(p_shape_definition is Vector3, "Shape definition for a Box must be a Vector3")
 		col = CollisionShape3D.new()
 		col.shape = BoxShape3D.new()
 		col.shape.size = p_shape_definition
@@ -80,8 +86,7 @@ func get_collision_shape(p_shape_definition, p_shape_type := TestCollisionShape.
 		col.shape = cached_high_poly_convex
 	elif p_shape_type == TestCollisionShape.CONVEX_POLYGON_ULTRA_HIGH_VERTEX:
 		col = CollisionShape3D.new()
-		col.shape = cached_ultra_high_poly_convex		
-		
+		col.shape = cached_ultra_high_poly_convex
 	elif p_shape_type == TestCollisionShape.CONVEX_POLYGON:
 		col = CollisionShape3D.new()
 		col.shape = cached_poly_convex
@@ -97,6 +102,8 @@ func get_default_shape_definition(p_shape_type : TestCollisionShape, p_scale := 
 		return 0.5 * p_scale
 	if p_shape_type == TestCollisionShape.CAPSULE:
 		return Vector2(1,2) * p_scale
+	if p_shape_type == TestCollisionShape.CYLINDER:
+		return Vector2(.5, 1.0) * p_scale
 	if p_shape_type == TestCollisionShape.CONVEX_POLYGON_MEDIUM_VERTEX  or p_shape_type == TestCollisionShape.CONVEX_POLYGON_HIGH_VERTEX or p_shape_type == TestCollisionShape.CONVEX_POLYGON or p_shape_type == TestCollisionShape.CONVEX_POLYGON_ULTRA_HIGH_VERTEX:
 		return null
 	
@@ -106,6 +113,7 @@ func get_default_shape_definition(p_shape_type : TestCollisionShape, p_scale := 
 static func shape_name(p_shape_type : TestCollisionShape) -> String:
 	match p_shape_type:
 		TestCollisionShape.CAPSULE: return "Capsule"
+		TestCollisionShape.CYLINDER: return "Cylinder"
 		TestCollisionShape.CONCAVE_POLYGON: return "Concave Polygon"
 		TestCollisionShape.CONVEX_POLYGON: return "Convex 8v"
 		TestCollisionShape.CONVEX_POLYGON_MEDIUM_VERTEX: return "Convex 146v"

--- a/tests/nodes/CharacterBody/character_body_3d.tscn
+++ b/tests/nodes/CharacterBody/character_body_3d.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=3 format=3 uid="uid://vi40lbum7hk5"]
+
+[ext_resource type="PackedScene" uid="uid://c223pyi3d8dmw" path="res://tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.tscn" id="1_oc7v8"]
+
+[sub_resource type="GDScript" id="GDScript_4th54"]
+script/source = "extends TestScene
+"
+
+[node name="character_body_3d" type="Node3D"]
+script = SubResource("GDScript_4th54")
+
+[node name="slide_along_box" parent="." instance=ExtResource("1_oc7v8")]
+
+[node name="slide_along_sphere" parent="." instance=ExtResource("1_oc7v8")]
+static_body_shape = 2
+
+[node name="slide_along_upright_cylinder_circle" parent="." instance=ExtResource("1_oc7v8")]
+static_body_shape = 5
+static_body_position = Vector3(6, 0, 0)
+character_body_shapes_failing = [6, 99, 100, 101]
+
+[node name="slide_along_sideways_cylinder_cap" parent="." instance=ExtResource("1_oc7v8")]
+static_body_shape = 5
+static_body_position = Vector3(6, 0, 0)
+static_body_rotation_degrees = Vector3(90, 0, 0)
+character_body_shapes_failing = [4]
+
+[node name="slide_along_sideways_cylinder_edge" parent="." instance=ExtResource("1_oc7v8")]
+static_body_shape = 5
+static_body_position = Vector3(6, 0, 0)
+static_body_rotation_degrees = Vector3(90, 90, 0)
+character_body_shapes_failing = [4, 100, 101, 5]

--- a/tests/nodes/CharacterBody/scripts/3d/character_body_3d_move_and_slide.gd
+++ b/tests/nodes/CharacterBody/scripts/3d/character_body_3d_move_and_slide.gd
@@ -1,0 +1,4 @@
+extends CharacterBody3D
+
+func _physics_process(_delta: float) -> void:
+	move_and_slide()

--- a/tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.gd
+++ b/tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.gd
@@ -1,0 +1,105 @@
+extends PhysicsUnitTest3D
+
+@export var static_body_shape: PhysicsTest3D.TestCollisionShape = PhysicsTest3D.TestCollisionShape.BOX
+@export var static_body_position: Vector3 = Vector3(5,0,0)
+@export var static_body_rotation_degrees: Vector3
+@export var static_body_scale: float = 10.0
+@export var character_body_speed = 30.0
+@export var character_body_rotation_degrees: Vector3
+@export var character_body_shapes_failing: Array[PhysicsTest3D.TestCollisionShape]
+
+var simulation_duration := 6.0
+var char_velocity: Vector3
+
+enum State {
+	ARRIVING,
+	TOUCHING,
+	DEPARTING,
+}
+
+func test_description() -> String:
+	return "Checks that the body slides along a %s static body." % [PhysicsTest3D.shape_name(static_body_shape)]
+
+func test_name() -> String:
+	return "CharacterBody3D | testing if the body can slide along a %s static body, params: [speed:%s]" % [PhysicsTest3D.shape_name(static_body_shape), character_body_speed]
+
+func test_start() -> void:
+	var slide_test_cbk = func(p_target: CharacterBody3D, p_monitor: GenericManualMonitor):
+		if p_monitor.first_iteration:
+			p_monitor.data['state'] = State.ARRIVING
+			p_monitor.data['impact_pos'] = Vector3(INF, INF, INF)
+		match p_monitor.data['state']:
+			State.ARRIVING:
+				if p_target.get_slide_collision_count() > 0:
+					p_monitor.data['state'] = State.TOUCHING
+					p_monitor.data['impact_pos'] = p_target.position
+			State.TOUCHING:
+				if p_target.velocity.length_squared() < 1.0:
+					p_monitor.failed("Got stuck while touching.")
+				if p_target.get_slide_collision_count() == 0:
+					p_monitor.data['state'] = State.DEPARTING
+			State.DEPARTING:
+				if p_target.velocity.length_squared() < 1.0:
+					p_monitor.failed("Got stuck during departure.")
+		if p_monitor.frame == 60*4:
+			if p_monitor.data['state'] != State.DEPARTING:
+				p_monitor.failed("Failed to reach departing state.")
+			elif p_target.position.x >= p_monitor.data['impact_pos'].x:
+				p_monitor.failed("Failed to slide in the correct direction.")
+			else:
+				p_monitor.passed()
+		# Always keep going.
+		p_target.velocity = char_velocity
+
+	var cpt := 1
+	for char_shape in PhysicsTest3D.TestCollisionShape.values():
+		# FIXME: Skip trimesh characters for now, due to lack of trimesh - trimesh collision support.
+		if char_shape == PhysicsTest3D.TestCollisionShape.CONCAVE_POLYGON:
+			continue
+		# FIXME: Skip high poly convex characters for now, due to performance issues.
+		if char_shape in [PhysicsTest3D.TestCollisionShape.CONVEX_POLYGON_HIGH_VERTEX, PhysicsTest3D.TestCollisionShape.CONVEX_POLYGON_ULTRA_HIGH_VERTEX]:
+			continue
+
+		# Create static body.
+		var static_body = create_static(cpt, static_body_position, static_body_shape)
+		static_body.rotation_degrees = static_body_rotation_degrees
+		add_child(static_body)
+
+		# Create character body.
+		char_velocity = Vector3(-1, 0, -1).normalized() * character_body_speed
+		var spawn_pos = -char_velocity * 2.0
+		var char_body := create_character(cpt, spawn_pos, char_shape)
+		char_body.velocity = char_velocity
+		char_body.rotation_degrees = character_body_rotation_degrees
+		add_child(char_body)
+
+		# Create slide monitor.
+		var slide_monitor = create_generic_manual_monitor(char_body, slide_test_cbk, simulation_duration)
+		slide_monitor.test_name = "%s can slide along %s"  % [PhysicsTest3D.shape_name(char_shape), PhysicsTest3D.shape_name(static_body_shape)]
+		if char_shape in character_body_shapes_failing:
+			slide_monitor.expected_to_fail = true
+
+		cpt += 1
+
+func create_character(p_layer: int, p_position: Vector3, p_body_shape := PhysicsTest3D.TestCollisionShape.CAPSULE) -> CharacterBody3D:
+	var character = CharacterBody3D.new()
+	character.script = load("res://tests/nodes/CharacterBody/scripts/3d/character_body_3d_move_and_slide.gd")
+	character.position = p_position
+	character.collision_layer = 0
+	character.collision_mask = 0
+	character.set_collision_layer_value(p_layer, true)
+	character.set_collision_mask_value(p_layer, true)
+	var body_col: Node3D = get_default_collision_shape(p_body_shape, 2)
+	character.add_child(body_col)
+	return character
+
+func create_static(p_layer: int, p_position: Vector3, p_body_shape := PhysicsTest3D.TestCollisionShape.BOX) -> StaticBody3D:
+	var static_body = StaticBody3D.new()
+	static_body.position = p_position
+	static_body.collision_layer = 0
+	static_body.collision_mask = 0
+	static_body.set_collision_layer_value(p_layer, true)
+	static_body.set_collision_mask_value(p_layer, true)
+	var body_col: Node3D = get_default_collision_shape(p_body_shape, static_body_scale)
+	static_body.add_child(body_col)
+	return static_body

--- a/tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.tscn
+++ b/tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://c223pyi3d8dmw"]
+
+[ext_resource type="Script" path="res://tests/nodes/CharacterBody/tests/character_body_3d/slide_along_static_body.gd" id="1_ayvab"]
+
+[node name="slide_along_static_body" type="Node3D"]
+script = ExtResource("1_ayvab")
+
+[node name="Camera" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 13, 0)


### PR DESCRIPTION
Video:

[character_slide_along_static.webm](https://user-images.githubusercontent.com/229837/211926708-60c58cd4-7b9c-4bee-b778-55e705b93191.webm)

Example text output, referring to the last test in the video:
```
> Checks that the body slides along a Cylinder static body.
 → Capsule can slide along Cylinder : ✗
 Got stuck during departure. 
 → Convex 8v can slide along Cylinder : ✓
 → Convex 146v can slide along Cylinder : ✓
 → Convex 1026v can slide along Cylinder : ✗
 Got stuck while touching. 
 → Convex 2050v can slide along Cylinder : ✗
 Got stuck while touching. 
 → Box can slide along Cylinder : ✓
 → Sphere can slide along Cylinder : ✓
 → Cylinder can slide along Cylinder : ✗
 Got stuck during departure.
```