### PR TITLE
CharacterBody2D floating mode tests

### DIFF
--- a/tests/nodes/CharacterBody/character_body_2d.tscn
+++ b/tests/nodes/CharacterBody/character_body_2d.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://dl8jh1yybnmc7"]
+[gd_scene load_steps=7 format=3 uid="uid://dl8jh1yybnmc7"]
 
 [ext_resource type="Script" path="res://base/class/test_scene_child.gd" id="1_dma0p"]
 [ext_resource type="PackedScene" uid="uid://bcvyoyk4gx8hd" path="res://tests/nodes/CharacterBody/tests/character_body_2d/detect_surface_type_with_pressure.tscn" id="2_eie1l"]
 [ext_resource type="PackedScene" uid="uid://clt6d1xruk034" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floor_snap_length.tscn" id="3_6m7xl"]
 [ext_resource type="PackedScene" path="res://tests/nodes/CharacterBody/tests/character_body_2d/slide_on_ceiling.tscn" id="4_c1exd"]
 [ext_resource type="PackedScene" uid="uid://b8c3ipxt4fjlo" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floor_constant_speed.tscn" id="5_q1u5f"]
+[ext_resource type="PackedScene" uid="uid://bqb1obldpyahv" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.tscn" id="6_n8228"]
 
 [node name="Scene" type="Node"]
 script = ExtResource("1_dma0p")
@@ -16,3 +17,5 @@ script = ExtResource("1_dma0p")
 [node name="testing_slide_on_ceiling_cap" parent="." instance=ExtResource("4_c1exd")]
 
 [node name="constant_speed" parent="." instance=ExtResource("5_q1u5f")]
+
+[node name="floating_min_slide_angle" parent="." instance=ExtResource("6_n8228")]

--- a/tests/nodes/CharacterBody/character_body_2d.tscn
+++ b/tests/nodes/CharacterBody/character_body_2d.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dl8jh1yybnmc7"]
+[gd_scene load_steps=8 format=3 uid="uid://dl8jh1yybnmc7"]
 
 [ext_resource type="Script" path="res://base/class/test_scene_child.gd" id="1_dma0p"]
 [ext_resource type="PackedScene" uid="uid://bcvyoyk4gx8hd" path="res://tests/nodes/CharacterBody/tests/character_body_2d/detect_surface_type_with_pressure.tscn" id="2_eie1l"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" path="res://tests/nodes/CharacterBody/tests/character_body_2d/slide_on_ceiling.tscn" id="4_c1exd"]
 [ext_resource type="PackedScene" uid="uid://b8c3ipxt4fjlo" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floor_constant_speed.tscn" id="5_q1u5f"]
 [ext_resource type="PackedScene" uid="uid://bqb1obldpyahv" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.tscn" id="6_n8228"]
+[ext_resource type="PackedScene" uid="uid://bnb4q7ofq0735" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.tscn" id="7_vy6w0"]
 
 [node name="Scene" type="Node"]
 script = ExtResource("1_dma0p")
@@ -19,3 +20,5 @@ script = ExtResource("1_dma0p")
 [node name="constant_speed" parent="." instance=ExtResource("5_q1u5f")]
 
 [node name="floating_min_slide_angle" parent="." instance=ExtResource("6_n8228")]
+
+[node name="floating_slides" parent="." instance=ExtResource("7_vy6w0")]

--- a/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.gd
+++ b/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.gd
@@ -3,8 +3,8 @@ extends PhysicsUnitTest2D
 var speed := 750
 var simulation_duration := 1
 
-@onready var spawn_1 := $Spawn1 # max_x < 800
-@onready var spawn_2 := $Spawn2 # max_x > 800
+@onready var spawn_1 := $Spawn1 # max_x < 525
+@onready var spawn_2 := $Spawn2 # max_x > 525
 
 func test_description() -> String:
 	return """Checks if [wall_min_slide_angle] is working properly. The body should not slide when

--- a/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.gd
+++ b/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.gd
@@ -1,0 +1,49 @@
+extends PhysicsUnitTest2D
+
+var speed := 750
+var simulation_duration := 1
+
+@onready var spawn_1 := $Spawn1 # max_x < 800
+@onready var spawn_2 := $Spawn2 # max_x > 800
+
+func test_description() -> String:
+	return """Checks if [wall_min_slide_angle] is working properly. The body should not slide when
+	meeting a wall at an angle less than [wall_min_slide_angle].
+	"""
+	
+func test_name() -> String:
+	return "CharacterBody2D | testing [wall_min_slide_angle]"
+
+func test_start() -> void:
+	var callback_lambda = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		if p_target.position.x > p_monitor.data["maximum_x"]:
+			p_monitor.data["maximum_x"] = p_target.position.x
+	
+	var character_lower := create_character(spawn_1.position)
+	
+	var test_lambda_lower: Callable = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		return p_monitor.data["maximum_x"] < 525
+	
+	var monitor_angle_lower := create_generic_expiration_monitor(character_lower, test_lambda_lower, callback_lambda, simulation_duration)
+	monitor_angle_lower.test_name = "The body stops when hitting at an angle less than [wall_min_slide_angle]"
+	monitor_angle_lower.data["maximum_x"] = 0
+
+	var character_higher := create_character(spawn_2.position)
+	
+	var test_lambda_higher: Callable = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		return p_monitor.data["maximum_x"] > 525
+	
+	var monitor_angle_greater := create_generic_expiration_monitor(character_higher, test_lambda_higher, callback_lambda, simulation_duration)
+	monitor_angle_greater.test_name = "The body slides when hitting at an angle greater than [wall_min_slide_angle]"
+	monitor_angle_greater.data["maximum_x"] = 0
+	
+func create_character(p_position: Vector2, p_body_shape := PhysicsTest2D.TestCollisionShape.RECTANGLE) -> CharacterBody2D:
+	var character = CharacterBody2D.new()
+	character.script = load("res://tests/nodes/CharacterBody/scripts/2d/character_body_2d_move_and_slide.gd")
+	character.position = p_position
+	character.velocity = Vector2(speed, 0.0)
+	character.motion_mode = CharacterBody2D.MOTION_MODE_FLOATING
+	var body_col: Node2D = PhysicsTest2D.get_default_collision_shape(p_body_shape, 2)
+	character.add_child(body_col)
+	add_child(character)
+	return character

--- a/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.tscn
+++ b/tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://bqb1obldpyahv"]
+
+[ext_resource type="Script" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floating_min_slide_angle.gd" id="1_c8714"]
+
+[node name="floating_min_slide_angle" type="Node2D"]
+script = ExtResource("1_c8714")
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+position = Vector2(600, 325)
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="StaticBody2D"]
+polygon = PackedVector2Array(-100, 0, 0, -400, 0, 355)
+
+[node name="Spawn1" type="Marker2D" parent="."]
+position = Vector2(400, 225)
+
+[node name="Spawn2" type="Marker2D" parent="."]
+position = Vector2(400, 425)

--- a/tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.gd
+++ b/tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.gd
@@ -1,0 +1,63 @@
+extends PhysicsUnitTest2D
+
+var speed := 750
+var simulation_duration := 1.0
+var tolerance := 0.001 # 1/1000 of speed
+
+@onready var spawn_1 := $Spawn1
+@onready var spawn_2 := $Spawn2
+@onready var spawn_3 := $Spawn3
+@onready var spawn_4 := $Spawn4
+
+func test_description() -> String:
+	return """Checks that bodies in FLOATING mode slide properly on walls.
+	"""
+	
+func test_name() -> String:
+	return "CharacterBody2D | testing FLOATING mode sliding"
+
+func test_start() -> void:
+	var callback_lambda = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		pass
+
+	var test_lambda: Callable = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		return (not p_target.is_on_wall()) \
+				and (p_target.velocity - p_monitor.data["target_v"]).length() < speed * tolerance
+	
+	var test_lambda_stop: Callable = func(p_target: CharacterBody2D, p_monitor: GenericExpirationMonitor):
+		return p_target.is_on_wall() and p_target.velocity.is_zero_approx()
+	
+	var character_1 := create_character(spawn_1.position, 1)
+	var monitor_1 := create_generic_expiration_monitor(character_1, test_lambda_stop, callback_lambda, simulation_duration)
+	monitor_1.test_name = "The body stops when hitting perpendicularly"
+	
+	var character_2 := create_character(spawn_2.position, 2)
+	var monitor_2 := create_generic_expiration_monitor(character_2, test_lambda, callback_lambda, simulation_duration)
+	monitor_2.test_name = "The body slides correctly at 30 degrees"
+	monitor_2.data["target_v"] = speed * Vector2(sin(PI/6),0.0).rotated(-PI/3)
+	
+	var character_3 := create_character(spawn_3.position, 3)
+	var monitor_3 := create_generic_expiration_monitor(character_3, test_lambda, callback_lambda, simulation_duration)
+	monitor_3.test_name = "The body slides correctly at 45 degrees"
+	monitor_3.data["target_v"] = speed * Vector2(sin(PI/4),0.0).rotated(-PI/4)
+	
+	var character_4 := create_character(spawn_4.position, 4)
+	var monitor_4 := create_generic_expiration_monitor(character_4, test_lambda, callback_lambda, simulation_duration)
+	monitor_4.test_name = "The body slides correctly at 60 degrees"
+	monitor_4.data["target_v"] = speed * Vector2(sin(PI/3),0.0).rotated(-PI/6)
+	
+func create_character(p_position: Vector2, p_layer : int, p_body_shape := PhysicsTest2D.TestCollisionShape.RECTANGLE) -> CharacterBody2D:
+	var character = CharacterBody2D.new()
+	character.script = load("res://tests/nodes/CharacterBody/scripts/2d/character_body_2d_move_and_slide.gd")
+	character.position = p_position
+	character.velocity = Vector2(speed, 0.0)
+	character.collision_layer = 0
+	character.collision_mask = 0
+	character.set_collision_layer_value(p_layer, true)
+	character.set_collision_mask_value(p_layer, true)
+	character.motion_mode = CharacterBody2D.MOTION_MODE_FLOATING
+	character.wall_min_slide_angle = 0 # covered by another test
+	var body_col: Node2D = PhysicsTest2D.get_default_collision_shape(p_body_shape, 2)
+	character.add_child(body_col)
+	add_child(character)
+	return character

--- a/tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.tscn
+++ b/tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=3 format=3 uid="uid://bnb4q7ofq0735"]
+
+[ext_resource type="Script" path="res://tests/nodes/CharacterBody/tests/character_body_2d/floating_slides.gd" id="1_ivi4y"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_dsbn4"]
+size = Vector2(20, 300)
+
+[node name="floating_slides" type="Node2D"]
+script = ExtResource("1_ivi4y")
+
+[node name="StaticBody2D1" type="StaticBody2D" parent="."]
+position = Vector2(1088, 512)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D1"]
+shape = SubResource("RectangleShape2D_dsbn4")
+
+[node name="StaticBody2D2" type="StaticBody2D" parent="."]
+position = Vector2(800, 512)
+rotation = 0.523599
+collision_layer = 2
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D2"]
+shape = SubResource("RectangleShape2D_dsbn4")
+
+[node name="StaticBody2D3" type="StaticBody2D" parent="."]
+position = Vector2(528, 512)
+rotation = 0.785398
+collision_layer = 4
+collision_mask = 4
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D3"]
+shape = SubResource("RectangleShape2D_dsbn4")
+
+[node name="StaticBody2D4" type="StaticBody2D" parent="."]
+position = Vector2(256, 512)
+rotation = 1.0472
+collision_layer = 8
+collision_mask = 8
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D4"]
+shape = SubResource("RectangleShape2D_dsbn4")
+
+[node name="Spawn1" type="Marker2D" parent="."]
+position = Vector2(944, 512)
+
+[node name="Spawn2" type="Marker2D" parent="."]
+position = Vector2(672, 512)
+
+[node name="Spawn3" type="Marker2D" parent="."]
+position = Vector2(400, 512)
+
+[node name="Spawn4" type="Marker2D" parent="."]
+position = Vector2(64, 512)


### PR DESCRIPTION
This adds a few basic tests of floating mode for CharacterBody2D.  The slide test fails on Godot's current master branch, but [https://github.com/godotengine/godot/pull/67662](url) fixes the problem as expected.