### PR TITLE
Add tests for rigid body CCD against trimesh/concave wall

### DIFF
--- a/base/class/physics_test_2d.gd
+++ b/base/class/physics_test_2d.gd
@@ -169,6 +169,12 @@ static func shape_name(p_shape_type : TestCollisionShape) -> String:
 			assert(false, "TestCollisionShape %d name is not implemented")
 			return "Not implemented"
 
+static func get_box_segments(width: float, height: float) -> PackedVector2Array:
+	return [Vector2(+0.5 * width, +0.5 * height),
+			Vector2(-0.5 * width, +0.5 * height),
+			Vector2(-0.5 * width, -0.5 * height),
+			Vector2(+0.5 * width, -0.5 * height)]
+
 static func concave_array():
 	return [
 		Vector2(6.0, -10.0),

--- a/base/class/physics_test_3d.gd
+++ b/base/class/physics_test_3d.gd
@@ -80,6 +80,11 @@ static func get_collision_shape(p_shape_definition, p_shape_type := TestCollisio
 		col = CollisionShape3D.new()
 		col.shape = BoxShape3D.new()
 		col.shape.size = p_shape_definition
+	elif p_shape_type == TestCollisionShape.CONCAVE_POLYGON:
+		assert(p_shape_definition is PackedVector3Array, "Shape definition for a Concave Polygon must be a PackedVector3Array")
+		col = CollisionShape3D.new()
+		col.shape = ConcavePolygonShape3D.new()
+		col.shape.set_faces(p_shape_definition)
 	elif p_shape_type == TestCollisionShape.CONVEX_POLYGON_MEDIUM_VERTEX:
 		col = CollisionShape3D.new()
 		col.shape = cached_medium_poly_convex
@@ -96,7 +101,7 @@ static func get_collision_shape(p_shape_definition, p_shape_type := TestCollisio
 
 static func get_default_collision_shape(p_shape_type : TestCollisionShape, p_scale := 1.0):
 	return get_collision_shape(get_default_shape_definition(p_shape_type, p_scale), p_shape_type)
-	
+
 static func get_default_shape_definition(p_shape_type : TestCollisionShape, p_scale := 1.0):
 	if p_shape_type == TestCollisionShape.BOX:
 		return Vector3(1 * p_scale, 1 * p_scale, 1 * p_scale)
@@ -106,6 +111,8 @@ static func get_default_shape_definition(p_shape_type : TestCollisionShape, p_sc
 		return Vector2(1,2) * p_scale
 	if p_shape_type == TestCollisionShape.CYLINDER:
 		return Vector2(.5, 1.0) * p_scale
+	if p_shape_type == TestCollisionShape.CONCAVE_POLYGON:
+		return get_trimesh_box_faces(p_scale, p_scale, p_scale)
 	if p_shape_type == TestCollisionShape.CONVEX_POLYGON_MEDIUM_VERTEX  or p_shape_type == TestCollisionShape.CONVEX_POLYGON_HIGH_VERTEX or p_shape_type == TestCollisionShape.CONVEX_POLYGON or p_shape_type == TestCollisionShape.CONVEX_POLYGON_ULTRA_HIGH_VERTEX:
 		return null
 	
@@ -128,7 +135,21 @@ static func shape_name(p_shape_type : TestCollisionShape) -> String:
 			@warning_ignore("assert_always_false")
 			assert(false, "TestCollisionShape %d name is not implemented")
 			return "Not implemented"
-			
+
+static func get_trimesh_box_faces(width: float, height: float, depth: float) -> PackedVector3Array:
+	return [Vector3(-0.5 * width, +0.5 * height, +0.5 * depth), Vector3(+0.5 * width, +0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, +0.5 * depth),
+			Vector3(+0.5 * width, +0.5 * height, +0.5 * depth), Vector3(+0.5 * width, -0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, +0.5 * depth),
+			Vector3(+0.5 * width, +0.5 * height, -0.5 * depth), Vector3(-0.5 * width, +0.5 * height, -0.5 * depth), Vector3(+0.5 * width, -0.5 * height, -0.5 * depth),
+			Vector3(-0.5 * width, +0.5 * height, -0.5 * depth), Vector3(-0.5 * width, -0.5 * height, -0.5 * depth), Vector3(+0.5 * width, -0.5 * height, -0.5 * depth),
+			Vector3(+0.5 * width, +0.5 * height, +0.5 * depth), Vector3(+0.5 * width, +0.5 * height, -0.5 * depth), Vector3(+0.5 * width, -0.5 * height, +0.5 * depth),
+			Vector3(+0.5 * width, +0.5 * height, -0.5 * depth), Vector3(+0.5 * width, -0.5 * height, -0.5 * depth), Vector3(+0.5 * width, -0.5 * height, +0.5 * depth),
+			Vector3(-0.5 * width, +0.5 * height, -0.5 * depth), Vector3(-0.5 * width, +0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, -0.5 * depth),
+			Vector3(-0.5 * width, +0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, -0.5 * depth),
+			Vector3(+0.5 * width, +0.5 * height, +0.5 * depth), Vector3(-0.5 * width, +0.5 * height, +0.5 * depth), Vector3(+0.5 * width, +0.5 * height, -0.5 * depth),
+			Vector3(-0.5 * width, +0.5 * height, +0.5 * depth), Vector3(-0.5 * width, +0.5 * height, -0.5 * depth), Vector3(+0.5 * width, +0.5 * height, -0.5 * depth),
+			Vector3(-0.5 * width, -0.5 * height, +0.5 * depth), Vector3(+0.5 * width, -0.5 * height, +0.5 * depth), Vector3(-0.5 * width, -0.5 * height, -0.5 * depth),
+			Vector3(+0.5 * width, -0.5 * height, +0.5 * depth), Vector3(+0.5 * width, -0.5 * height, -0.5 * depth), Vector3(-0.5 * width, -0.5 * height, -0.5 * depth)]
+
 var zoom_factor := 5
 var dragging = false
 func _unhandled_input(event):

--- a/tests/nodes/RigidBody/rigid_body_2d.tscn
+++ b/tests/nodes/RigidBody/rigid_body_2d.tscn
@@ -15,7 +15,10 @@ script = ExtResource("1_6eclx")
 
 [node name="maximum_rectangle" parent="." instance=ExtResource("2_p0tuo")]
 
-[node name="continuous_detection" parent="." instance=ExtResource("3_2mxd6")]
+[node name="continuous_detection_box" parent="." instance=ExtResource("3_2mxd6")]
+
+[node name="continuous_detection_concave" parent="." instance=ExtResource("3_2mxd6")]
+wall_type = 1
 
 [node name="contact_monitor" parent="." instance=ExtResource("4_n6ed2")]
 

--- a/tests/nodes/RigidBody/rigid_body_3d.tscn
+++ b/tests/nodes/RigidBody/rigid_body_3d.tscn
@@ -21,4 +21,9 @@ shape = 2
 stack_height = 42
 simulation_duration = 6
 
-[node name="continuous_detection" parent="." instance=ExtResource("2_ek4cl")]
+[node name="continuous_detection_box" parent="." instance=ExtResource("2_ek4cl")]
+expected_to_fail = Array[int]([0])
+
+[node name="continuous_detection_concave" parent="." instance=ExtResource("2_ek4cl")]
+wall_type = 1
+expected_to_fail = Array[int]([1, 3])

--- a/tests/nodes/RigidBody/tests/2d/continuous_detection.gd
+++ b/tests/nodes/RigidBody/tests/2d/continuous_detection.gd
@@ -1,7 +1,13 @@
 extends PhysicsUnitTest2D
 
-var speed := 25000
-var simulation_duration := .1
+enum WallType {
+	BOX,
+	CONCAVE_BOX
+}
+
+@export var wall_type: WallType = WallType.BOX
+@export var speed: float = 25000
+@export var simulation_duration : float = 0.1
 
 func test_description() -> String:
 	return """Checks if the Continuous Collision Detection (CCD) is working, it must ensure that moving
@@ -15,15 +21,28 @@ var detect_x_collision := false
 var detect_y_collision := false
 
 func test_start() -> void:
-	
-	var vertical_wall = PhysicsTest2D.get_static_body_with_collision_shape(Rect2(Vector2(0,0), Vector2(2, Global.WINDOW_SIZE.y)), PhysicsTest2D.TestCollisionShape.RECTANGLE, true)
+	var vertical_wall := StaticBody2D.new()
+	var vertical_wall_shape: Node2D = null
+	if wall_type == WallType.BOX:
+		vertical_wall_shape = PhysicsTest2D.get_collision_shape(Rect2(Vector2(0,0), Vector2(2, Global.WINDOW_SIZE.y)), PhysicsTest2D.TestCollisionShape.RECTANGLE, true)
+	elif wall_type == WallType.CONCAVE_BOX:
+		vertical_wall_shape = PhysicsTest2D.get_collision_shape(PhysicsTest2D.get_box_segments(2, Global.WINDOW_SIZE.y), PhysicsTest2D.TestCollisionShape.CONCAVE_POLYGON)
+		vertical_wall_shape.position += Vector2(1, 0.5 * Global.WINDOW_SIZE.y)
+	vertical_wall.add_child(vertical_wall_shape)
 	vertical_wall.position = Vector2(TOP_RIGHT.x - Global.WINDOW_SIZE.y/2 -1, 0)
 	add_child(vertical_wall)
-	
-	var horizontal_wall = PhysicsTest2D.get_static_body_with_collision_shape(Rect2(Vector2(0,0), Vector2(Global.WINDOW_SIZE.y/2, 2)), PhysicsTest2D.TestCollisionShape.RECTANGLE, true)
+
+	var horizontal_wall := StaticBody2D.new()
+	var horizontal_wall_shape: Node2D = null
+	if wall_type == WallType.BOX:
+		horizontal_wall_shape = PhysicsTest2D.get_collision_shape(Rect2(Vector2(0,0), Vector2(0.5 * Global.WINDOW_SIZE.y, 2)), PhysicsTest2D.TestCollisionShape.RECTANGLE, true)
+	elif wall_type == WallType.CONCAVE_BOX:
+		horizontal_wall_shape = PhysicsTest2D.get_collision_shape(PhysicsTest2D.get_box_segments(0.5 * Global.WINDOW_SIZE.y, 2), PhysicsTest2D.TestCollisionShape.CONCAVE_POLYGON)
+		horizontal_wall_shape.position += Vector2(0.25 * Global.WINDOW_SIZE.y, 1)
+	horizontal_wall.add_child(horizontal_wall_shape)
 	horizontal_wall.position = Vector2(BOTTOM_RIGHT.x - Global.WINDOW_SIZE.y/2, BOTTOM_RIGHT.y -50)
 	add_child(horizontal_wall)
-	
+
 	var rigid_x_ccd_ray := create_rigid_body(RigidBody2D.CCD_MODE_CAST_RAY)
 	rigid_x_ccd_ray.position = Vector2(50, 150)
 	rigid_x_ccd_ray.body_entered.connect(x_collide.bind(rigid_x_ccd_ray))

--- a/tests/nodes/RigidBody/tests/3d/continuous_detection.gd
+++ b/tests/nodes/RigidBody/tests/3d/continuous_detection.gd
@@ -1,7 +1,21 @@
 extends PhysicsUnitTest3D
 
-var speed := 25000
-var simulation_duration := 0.1
+enum WallType {
+	BOX,
+	CONCAVE_BOX
+}
+
+enum Aspect {
+	HORIZONTAL_TUNNELING,
+	HORIZONTAL_DETECTION,
+	VERTICAL_TUNNELING,
+	VERTICAL_DETECTION
+}
+
+@export var wall_type: WallType = WallType.BOX
+@export var speed: float = 25000
+@export var simulation_duration: float = 0.1
+@export var expected_to_fail: Array[Aspect] = []
 
 func test_description() -> String:
 	return """Checks if the Continuous Collision Detection (CCD) is working, it must ensure that moving
@@ -15,11 +29,23 @@ var detect_x_collision := false
 var detect_y_collision := false
 
 func test_start() -> void:
-	var vertical_wall = PhysicsTest3D.get_static_body_with_collision_shape(Vector3(5000, 0.1, 5000), PhysicsTest3D.TestCollisionShape.BOX)
+	var vertical_wall := StaticBody3D.new()
+	var vertical_wall_shape: Node3D = null
+	if wall_type == WallType.BOX:
+		vertical_wall_shape = PhysicsTest3D.get_collision_shape(Vector3(5000, 0.1, 5000), PhysicsTest3D.TestCollisionShape.BOX)
+	elif wall_type == WallType.CONCAVE_BOX:
+		vertical_wall_shape = PhysicsTest3D.get_collision_shape(PhysicsTest3D.get_trimesh_box_faces(5000, 0.1, 5000), PhysicsTest3D.TestCollisionShape.CONCAVE_POLYGON)
+	vertical_wall.add_child(vertical_wall_shape)
 	vertical_wall.position = Vector3(8, -5, 0)
 	add_child(vertical_wall)
 
-	var horizontal_wall = PhysicsTest3D.get_static_body_with_collision_shape(Vector3(0.1, 5000, 5000), PhysicsTest3D.TestCollisionShape.BOX)
+	var horizontal_wall := StaticBody3D.new()
+	var horizontal_wall_shape: Node3D = null
+	if wall_type == WallType.BOX:
+		horizontal_wall_shape = PhysicsTest3D.get_collision_shape(Vector3(0.1, 5000, 5000), PhysicsTest3D.TestCollisionShape.BOX)
+	elif wall_type == WallType.CONCAVE_BOX:
+		horizontal_wall_shape = PhysicsTest3D.get_collision_shape(PhysicsTest3D.get_trimesh_box_faces(0.1, 5000, 5000), PhysicsTest3D.TestCollisionShape.CONCAVE_POLYGON)
+	horizontal_wall.add_child(horizontal_wall_shape)
 	horizontal_wall.position = Vector3(0, 2, 0)
 	add_child(horizontal_wall)
 
@@ -43,16 +69,23 @@ func test_start() -> void:
 	
 	var x_shape_ccd_monitor := create_generic_expiration_monitor(horizontal_rigid_body, x_lambda, null, simulation_duration)
 	x_shape_ccd_monitor.test_name = "Rigid moving in x with CCD does not pass through the wall"
-	x_shape_ccd_monitor.expected_to_fail = true
+	if Aspect.HORIZONTAL_TUNNELING in expected_to_fail:
+		x_shape_ccd_monitor.expected_to_fail = true
 	
 	var y_shape_ccd_monitor := create_generic_expiration_monitor(vertical_rigid_body, y_lambda, null, simulation_duration)
 	y_shape_ccd_monitor.test_name = "Rigid moving in y with CCD does not pass through the wall"
+	if Aspect.VERTICAL_TUNNELING in expected_to_fail:
+		y_shape_ccd_monitor.expected_to_fail = true
 	
 	var x_collision_monitor := create_generic_expiration_monitor(horizontal_rigid_body, collide_x_lambda, null, simulation_duration)
 	x_collision_monitor.test_name = "Rigid moving in x with CCD detects collision"
+	if Aspect.HORIZONTAL_DETECTION in expected_to_fail:
+		x_collision_monitor.expected_to_fail = true
 
 	var y_collision_monitor := create_generic_expiration_monitor(vertical_rigid_body, collide_y_lambda, null, simulation_duration)
 	y_collision_monitor.test_name = "Rigid moving in y with CCD detects collision"
+	if Aspect.VERTICAL_DETECTION in expected_to_fail:
+		y_collision_monitor.expected_to_fail = true
 
 	process_mode = Node.PROCESS_MODE_DISABLED # to be able to see something
 	await get_tree().create_timer(.1).timeout


### PR DESCRIPTION
Adds a test for issue

- https://github.com/godotengine/godot/issues/74756

as well as a 2D variant (which has no issue, and 4.0 stable passes that test).