### PR TITLE
Apply forces after add to fix some issues with Rapier

### DIFF
--- a/tests/nodes/CollisionShape/tests/2d/rigid_one_way_collision.gd
+++ b/tests/nodes/CollisionShape/tests/2d/rigid_one_way_collision.gd
@@ -46,10 +46,10 @@ func test_start() -> void:
 			var rigid = RigidBody2D.new()
 			rigid.add_child(PhysicsTest2D.get_default_collision_shape(body_shape, 0.5))
 			rigid.gravity_scale = 0
-			rigid.add_constant_force(Vector2(speed, 0))
 			rigid.position = center + Vector2(-20, 0)
 			bodies.append(rigid)
 			add_child(rigid)
+			rigid.add_constant_force(Vector2(speed, 0))
 			
 			wall_on_way.collision_layer = 0
 			wall_on_way.collision_mask = 0

--- a/tests/nodes/RigidBody/tests/2d/contact_monitor.gd
+++ b/tests/nodes/RigidBody/tests/2d/contact_monitor.gd
@@ -60,6 +60,6 @@ func create_rigid_body(p_layer := 1, p_report_contact := 20) -> RigidBody2D:
 	player.collision_mask = 0
 	player.collision_layer = 0
 	player.set_collision_mask_value(p_layer, true)
-	player.apply_force(Vector2(speed, 0))
 	add_child(player)
+	player.apply_force(Vector2(speed, 0))
 	return player

--- a/tests/nodes/RigidBody/tests/2d/continuous_detection.gd
+++ b/tests/nodes/RigidBody/tests/2d/continuous_detection.gd
@@ -84,8 +84,8 @@ func create_rigid_body(p_ccd_mode: RigidBody2D.CCDMode, p_horizontal := true, p_
 	player.max_contacts_reported = 2
 	player.rotation = 90 # Case where the movement vector was not properly being transformed into local space, see #69934
 	var force = Vector2(speed, 0) if p_horizontal else Vector2(0, speed)
-	player.apply_central_impulse(force)
 	add_child(player)
+	player.apply_central_impulse(force)
 	return player
 
 func x_collide(_body, _player):


### PR DESCRIPTION
Applying forces or velocity too early when creating a body is not supported at the moment.